### PR TITLE
Moved pin2int array const

### DIFF
--- a/SDISerial.cpp
+++ b/SDISerial.cpp
@@ -54,8 +54,9 @@ typedef struct _DELAY_TABLE
   unsigned short tx_delay;
 } DELAY_TABLE;
 
-#if F_CPU == 16000000
 static const uint8_t pin2int[23] = {-1, -1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 5, 2, 3};
+#if F_CPU == 16000000
+
 static const DELAY_TABLE PROGMEM table[] = 
 {
   //  baud    rxcenter   rxintra    rxstop    tx


### PR DESCRIPTION
Problems in compiling on a 8 Mhz Arduino Pro Mini 3V due to misplaced array statement.

